### PR TITLE
fix for issue #18

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,6 @@
 # Important Notice
 
 Reactuate is an example of literate programming. If you are considering making a contribution, please apply it against README.md (where the actual program is), not generated effects (pretty much all other files). Doing so will speed up merging your contribution greatly.
+
+To propagate changes made `README.md` to the rest of the project, either `npm install -g doctoc litpro` and `make`, or use `npm run make` to run the `npm install`ed versions.
+

--- a/README.md
+++ b/README.md
@@ -48,10 +48,7 @@ Reactuate is licensed under the terms of [Apache 2.0 license](LICENSE.md).
   - [Layout](#layout)
   - [Domain](#domain)
   - [Managing effects](#managing-effects)
-  - [Putting it all together](#putting-it-all-together)
-- [Example Application](#example-application)
 - [Appendix 1. Post-Installation Instructions](#appendix-1-post-installation-instructions)
-- [Appendix A. Package file](#appendix-a-package-file)
 - [Appendix B. .gitignore](#appendix-b-gitignore)
 - [Appendix B1. .npmignore](#appendix-b1-npmignore)
 
@@ -923,7 +920,7 @@ export default function(domain, initialState, ...cases) {
   let reducer = (state = initialState, action) => {
     let typedAction = action
     if (action['type'] === '@@reactuate/action') {
-      let actionCreator = domain.get('actions')[domain.withoutPrefix(action.meta.name)]
+      let actionCreator = domain.get('actions')[domain.withoutPrefix(action.payload.type)]
       if (!t.Nil.is(actionCreator)) {
         typedAction = actionCreator(action.payload.payload, action.payload.error, action.payload.meta)
       }

--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ Reactuate is licensed under the terms of [Apache 2.0 license](LICENSE.md).
   - [Layout](#layout)
   - [Domain](#domain)
   - [Managing effects](#managing-effects)
+  - [Putting it all together](#putting-it-all-together)
+- [Example Application](#example-application)
 - [Appendix 1. Post-Installation Instructions](#appendix-1-post-installation-instructions)
+- [Appendix A. Package file](#appendix-a-package-file)
 - [Appendix B. .gitignore](#appendix-b-gitignore)
 - [Appendix B1. .npmignore](#appendix-b1-npmignore)
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" &&   exit 1",
-    "make": "doctoc README.md && litpro -b . README.md",
     "postinstall": "node ./postinstall.js"
   },
   "repository": {
@@ -19,72 +18,61 @@
   ],
   "author": "Yurii Rashkovskii <yrashk@gmail.com>",
   "license": "Apache-2.0",
-  "engines": {
-    "node": ">=v5.4.1 <6.0"
-  },
+  "engines": {"node": ">=v5.4.1 <6.0"},
   "dependencies": {
-    "webpack": "1.12.14",
-    "html-webpack-plugin": "2.15.0",
-    "babel-loader": "6.2.4",
-    "babel-preset-es2015": "6.6.0",
-    "babel-preset-stage-0": "6.5.0-1",
-    "babel-plugin-transform-export-extensions": "6.5.0-1",
-    "babel-plugin-react-transform": "2.0.2",
-    "babel-preset-react": "6.5.0-1",
-    "babel-preset-react-hmre": "1.1.1",
-    "babel-plugin-transform-react-constant-elements": "6.5.0-1",
-    "babel-plugin-transform-react-inline-elements": "6.6.5",
-    "babel-plugin-transform-react-remove-prop-types": "0.2.4",
-    "deepest-merge": "0.1.1",
-    "json-loader": "0.5.4",
-    "style-loader": "0.13.1",
-    "css-loader": "0.23.1",
-    "less": "2.6.1",
-    "less-loader": "2.2.3",
-    "postcss-loader": "0.8.2",
-    "postcss-import": "8.0.2",
-    "globby": "4.0.0",
-    "file-loader": "0.8.5",
-    "url-loader": "0.5.7",
-    "raw-loader": "0.5.1",
-    "webpack-dev-server": "1.14.1",
-    "babel-core": "6.7.4",
-    "babel-register": "6.7.2",
-    "babel-polyfill": "6.7.4",
-    "react": "15.0.1",
-    "react-dom": "15.0.1",
-    "redux": "3.3.1",
-    "react-redux": "4.4.1",
-    "redux-thunk": "2.0.1",
-    "redux-logger": "2.6.1",
-    "react-router": "1.0.3",
-    "history": "1.17.0",
-    "redux-router": "1.0.0-beta8",
-    "tcomb": "3.0.0",
-    "tcomb-form-types": "1.1.0",
-    "flux-standard-action": "0.6.1",
-    "redux-saga": "0.9.5",
-    "yesno": "0.0.1"
+      "webpack": "1.12.14",
+      "html-webpack-plugin": "2.15.0",
+      "babel-loader": "6.2.4",
+      "babel-preset-es2015": "6.6.0",
+      "babel-preset-stage-0": "6.5.0-1",
+      "babel-plugin-transform-export-extensions": "6.5.0-1",
+      "babel-plugin-react-transform": "2.0.2",
+      "babel-preset-react": "6.5.0-1",
+      "babel-preset-react-hmre": "1.1.1",
+      "babel-plugin-transform-react-constant-elements": "6.5.0-1",
+      "babel-plugin-transform-react-inline-elements": "6.6.5",
+      "babel-plugin-transform-react-remove-prop-types": "0.2.4",
+      "deepest-merge": "0.1.1",
+      "json-loader": "0.5.4",
+      "style-loader": "0.13.1",
+      "css-loader": "0.23.1",
+      "less": "2.6.1",
+      "less-loader": "2.2.3",
+      "postcss-loader": "0.8.2",
+      "postcss-import": "8.0.2",
+      "globby": "4.0.0",
+      "file-loader": "0.8.5",
+      "url-loader": "0.5.7",
+      "raw-loader": "0.5.1",
+      "webpack-dev-server": "1.14.1",
+      "babel-core": "6.7.4",
+      "babel-register": "6.7.2",
+      "babel-polyfill": "6.7.4",
+      "react": "15.0.1",
+      "react-dom": "15.0.1",
+      "redux": "3.3.1",
+      "react-redux": "4.4.1",
+      "redux-thunk": "2.0.1",
+      "redux-logger": "2.6.1",
+      "react-router": "1.0.3",
+      "history": "1.17.0",
+      "redux-router": "1.0.0-beta8",
+      "tcomb": "3.0.0",
+      "tcomb-form-types": "1.1.0",
+      "flux-standard-action": "0.6.1",
+      "redux-saga": "0.9.5",
+      "yesno": "0.0.1"
   },
   "peerDependencies": {
-    "babel-core": "6.7.4"
+      "babel-core": "6.7.4"
   },
   "devDependencies": {
-    "doctoc": "^1.0.0",
-    "litpro": "^0.12.1"
+      "doctoc": "^1.0.0",
+      "litpro": "^0.12.1"
   },
   "bugs": {
     "url": "https://github.com/reactuate/reactuate/issues"
   },
   "homepage": "https://github.com/reactuate/reactuate#readme",
-  "babel": {
-    "presets": [
-      "react",
-      "es2015",
-      "stage-0"
-    ],
-    "plugins": [
-      "transform-export-extensions"
-    ]
-  }
+  "babel": {"presets":["react","es2015","stage-0"], "plugins":["transform-export-extensions"]}
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" &&   exit 1",
+    "make": "doctoc README.md && litpro -b . README.md",
     "postinstall": "node ./postinstall.js"
   },
   "repository": {
@@ -18,57 +19,72 @@
   ],
   "author": "Yurii Rashkovskii <yrashk@gmail.com>",
   "license": "Apache-2.0",
-  "engines": {"node": ">=v5.4.1 <6.0"},
+  "engines": {
+    "node": ">=v5.4.1 <6.0"
+  },
   "dependencies": {
-      "webpack": "1.12.14",
-      "html-webpack-plugin": "2.15.0",
-      "babel-loader": "6.2.4",
-      "babel-preset-es2015": "6.6.0",
-      "babel-preset-stage-0": "6.5.0-1",
-      "babel-plugin-transform-export-extensions": "6.5.0-1",
-      "babel-plugin-react-transform": "2.0.2",
-      "babel-preset-react": "6.5.0-1",
-      "babel-preset-react-hmre": "1.1.1",
-      "babel-plugin-transform-react-constant-elements": "6.5.0-1",
-      "babel-plugin-transform-react-inline-elements": "6.6.5",
-      "babel-plugin-transform-react-remove-prop-types": "0.2.4",
-      "deepest-merge": "0.1.1",
-      "json-loader": "0.5.4",
-      "style-loader": "0.13.1",
-      "css-loader": "0.23.1",
-      "less": "2.6.1",
-      "less-loader": "2.2.3",
-      "postcss-loader": "0.8.2",
-      "postcss-import": "8.0.2",
-      "globby": "4.0.0",
-      "file-loader": "0.8.5",
-      "url-loader": "0.5.7",
-      "raw-loader": "0.5.1",
-      "webpack-dev-server": "1.14.1",
-      "babel-core": "6.7.4",
-      "babel-register": "6.7.2",
-      "babel-polyfill": "6.7.4",
-      "react": "15.0.1",
-      "react-dom": "15.0.1",
-      "redux": "3.3.1",
-      "react-redux": "4.4.1",
-      "redux-thunk": "2.0.1",
-      "redux-logger": "2.6.1",
-      "react-router": "1.0.3",
-      "history": "1.17.0",
-      "redux-router": "1.0.0-beta8",
-      "tcomb": "3.0.0",
-      "tcomb-form-types": "1.1.0",
-      "flux-standard-action": "0.6.1",
-      "redux-saga": "0.9.5",
-      "yesno": "0.0.1"
+    "webpack": "1.12.14",
+    "html-webpack-plugin": "2.15.0",
+    "babel-loader": "6.2.4",
+    "babel-preset-es2015": "6.6.0",
+    "babel-preset-stage-0": "6.5.0-1",
+    "babel-plugin-transform-export-extensions": "6.5.0-1",
+    "babel-plugin-react-transform": "2.0.2",
+    "babel-preset-react": "6.5.0-1",
+    "babel-preset-react-hmre": "1.1.1",
+    "babel-plugin-transform-react-constant-elements": "6.5.0-1",
+    "babel-plugin-transform-react-inline-elements": "6.6.5",
+    "babel-plugin-transform-react-remove-prop-types": "0.2.4",
+    "deepest-merge": "0.1.1",
+    "json-loader": "0.5.4",
+    "style-loader": "0.13.1",
+    "css-loader": "0.23.1",
+    "less": "2.6.1",
+    "less-loader": "2.2.3",
+    "postcss-loader": "0.8.2",
+    "postcss-import": "8.0.2",
+    "globby": "4.0.0",
+    "file-loader": "0.8.5",
+    "url-loader": "0.5.7",
+    "raw-loader": "0.5.1",
+    "webpack-dev-server": "1.14.1",
+    "babel-core": "6.7.4",
+    "babel-register": "6.7.2",
+    "babel-polyfill": "6.7.4",
+    "react": "15.0.1",
+    "react-dom": "15.0.1",
+    "redux": "3.3.1",
+    "react-redux": "4.4.1",
+    "redux-thunk": "2.0.1",
+    "redux-logger": "2.6.1",
+    "react-router": "1.0.3",
+    "history": "1.17.0",
+    "redux-router": "1.0.0-beta8",
+    "tcomb": "3.0.0",
+    "tcomb-form-types": "1.1.0",
+    "flux-standard-action": "0.6.1",
+    "redux-saga": "0.9.5",
+    "yesno": "0.0.1"
   },
   "peerDependencies": {
-      "babel-core": "6.7.4"
+    "babel-core": "6.7.4"
+  },
+  "devDependencies": {
+    "doctoc": "^1.0.0",
+    "litpro": "^0.12.1"
   },
   "bugs": {
     "url": "https://github.com/reactuate/reactuate/issues"
   },
   "homepage": "https://github.com/reactuate/reactuate#readme",
-  "babel": {"presets":["react","es2015","stage-0"], "plugins":["transform-export-extensions"]}
+  "babel": {
+    "presets": [
+      "react",
+      "es2015",
+      "stage-0"
+    ],
+    "plugins": [
+      "transform-export-extensions"
+    ]
+  }
 }

--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -4,7 +4,7 @@ export default function(domain, initialState, ...cases) {
   let reducer = (state = initialState, action) => {
     let typedAction = action
     if (action['type'] === '@@reactuate/action') {
-      let actionCreator = domain.get('actions')[domain.withoutPrefix(action.meta.name)]
+      let actionCreator = domain.get('actions')[domain.withoutPrefix(action.payload.type)]
       if (!t.Nil.is(actionCreator)) {
         typedAction = actionCreator(action.payload.payload, action.payload.error, action.payload.meta)
       }


### PR DESCRIPTION
- allows different domains to have the same actions with the same names (issue #18)
- adds `doctoc` and `litpro` to devDependencies, as well as a `npm run make` script for a non-global development option
- documents contribution commands a bit more
